### PR TITLE
lazy loading aplicado a la web publica

### DIFF
--- a/src/app/features/app-routing.module.ts
+++ b/src/app/features/app-routing.module.ts
@@ -1,26 +1,8 @@
-import { ActivityFormComponent } from "./pages/activities/activity-form/activity-form.component";
-import { Component, NgModule } from "@angular/core";
-import { componentFactoryName } from "@angular/compiler";
+import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { RouterModule, Routes } from "@angular/router";
-import { RegisterFormComponent } from "./pages/auth/register-form/register-form.component";
-import { LoginFormComponent } from "./pages/auth/login-form/login-form.component";
-import { UsSectionComponent } from "./pages/about/us-section/us-section.component";
-import { ContactComponent } from "./pages/contact/contact.component";
-import { TestimonialFormComponent } from "./pages/testimonials/testimonial-form/testimonial-form.component";
-import { DetailComponent } from "./pages/activities/detail/detail.component";
-import { CategoriesFormComponent } from "./pages/categories/categories-form/categories-form.component";
-import { InicioComponent } from "./pages/home/inicio/inicio.component";
-import { UserFormComponent } from "./pages/users/user-form/user-form.component";
-import { ProjectsComponent } from "./pages/projects/projects.component";
-import { DetalleNovedadComponent } from "./pages/news/datail/detalle-novedad/detalle-novedad.component";
-import { ListActivitiesComponent } from "./pages/activities/list-activities/list-activities.component";
+
 import { ErrorComponent } from "./pages/error/error.component";
-import { NewsFormComponent } from "./pages/news/news-form/news-form.component";
-import { DatosContactoComponent } from "./pages/contact/components/datos-contacto/datos-contacto.component";
-import { ListNewsComponent } from "./pages/news/list-news/list-news.component";
-
-
 
 const routes: Routes = [
   {
@@ -28,82 +10,17 @@ const routes: Routes = [
     loadChildren: () =>
       import("./backoffice/backoffice.module").then((m) => m.BackofficeModule),
   },
-  {
-    path: "novedades/:id",
-    component: DetalleNovedadComponent,
-  },
-  {
-
-    path: "contact",
-    component: DatosContactoComponent
-  },
-
-  {
-    path: "novedades",
-    component: ListNewsComponent,
-  },
-
-  {
-    path: "contacto",
-    component: ContactComponent,
-  },
-  
-
-  {
-    path: "nosotros",
-    component: UsSectionComponent,
-  },
-
-  {
-    path: "usuarios",
-    component: UserFormComponent,
-  },
-  {
-    path: "login",
-    component: LoginFormComponent
-  },
-  {
-    path: "register",
-    component: RegisterFormComponent,
-  },
-  {
-    path: "proyectos",
-    component: ProjectsComponent,
-  },
-
-  {
-    path: "categorias",
-    component: CategoriesFormComponent,
-  },
-
-  {
-    path: "testimonios",
-    component: TestimonialFormComponent,
-  },
-
-  {
-    path: "actividades",
-    component: ListActivitiesComponent,
-  },
-
-  {
-    path: "actividades/:id",
-    component: DetailComponent,
-  },
-  {
-    path: "home",
-    component: InicioComponent,
-  },
 
   {
     path: "landing",
     loadChildren: () =>
       import("./landing/landing.module").then((m) => m.LandingModule),
   },
+
   {
     path: "",
-    redirectTo: "home",
-    pathMatch: "full",
+    loadChildren: () =>
+      import("./pages/web-public.module").then((m) => m.WebPublicModule)
   },
 
   {

--- a/src/app/features/features.module.ts
+++ b/src/app/features/features.module.ts
@@ -2,121 +2,30 @@ import { RouterModule } from "@angular/router";
 import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { AppRoutingModule } from "./app-routing.module";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
-import { MatSidenavModule } from "@angular/material/sidenav";
-import { MatDialogModule } from "@angular/material/dialog";
-import { MatToolbarModule } from "@angular/material/toolbar";
-import { MatIconModule } from "@angular/material/icon";
-import { MatButtonModule } from "@angular/material/button";
-import { ActivityFormComponent } from "./pages/activities/activity-form/activity-form.component";
-import { LoginFormComponent } from "./pages/auth/login-form/login-form.component";
-import { RegisterFormComponent } from "./pages/auth/register-form/register-form.component";
-import { NewsFormComponent } from "./pages/news/news-form/news-form.component";
-import { SlidesFormComponent } from "./pages/slides/slides-form/slides-form.component";
-import { TestimonialFormComponent } from "./pages/testimonials/testimonial-form/testimonial-form.component";
-import { UserFormComponent } from "./pages/users/user-form/user-form.component";
-import { MostrarTitulosComponent } from "../shared/components/mostrar-titulos/mostrar-titulos.component";
-import { UsSectionComponent } from "./pages/about/us-section/us-section.component";
-import { SobreNosotrosComponent } from "./pages/about/us-section/components/sobre-nosotros/sobre-nosotros.component";
-import { CKEditorModule } from "ckeditor4-angular";
-import { ContactFormComponent } from "./pages/contact/components/contact-form/contact-form.component";
-import { ContactComponent } from "./pages/contact/contact.component";
-import { ContributesInfoComponent } from "./pages/contact/components/contributes-info/contributes-info.component";
-import { OrganizationComponent } from "./pages/organization/organization.component";
-import { ListadoNosotrosComponent } from "./pages/about/us-section/components/listado-nosotros/listado-nosotros.component";
-import { DetailComponent } from "./pages/activities/detail/detail.component";
+
 import { StoreModule } from "@ngrx/store";
 import { ROOT_REDUCERS } from "../core/ngrx/app.store";
 import { EffectsModule } from "@ngrx/effects";
 import { ActividadEffects } from "../core/ngrx/effects/actividad.effect";
 import { StoreDevtoolsModule } from "@ngrx/store-devtools";
-import { InicioComponent } from "./pages/home/inicio/inicio.component";
-import { SliderComponent } from "./pages/home/slider/slider.component";
-import { SharedModule } from "../shared/shared.module";
-import { ProjectsComponent } from "./pages/projects/projects.component";
-import { DetalleNovedadComponent } from "./pages/news/datail/detalle-novedad/detalle-novedad.component";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { ListActivitiesComponent } from "./pages/activities/list-activities/list-activities.component";
-import { DashboardNovedadesComponent } from "./pages/news/dashboard-novedades/dashboard-novedades.component";
-import { ErrorComponent } from "./pages/error/error.component";
-import { ActivityContentComponent } from "./pages/activities/activity-content/activity-content.component";
-import { DatosContactoComponent } from "./pages/contact/components/datos-contacto/datos-contacto.component";
-import { PhonePipe } from "../core/pipes/phone/phone.pipe";
-import { ListNewsComponent } from "./pages/news/list-news/list-news.component";
-import { FooterComponent } from './pages/footer/footer.component';
-import { SearchComponent } from './pages/activities/search/search.component';
-import { HeaderComponent } from './pages/header/header.component';
-
-
-
 
 
 @NgModule({
-  declarations: [
-    ActivityFormComponent,
-    LoginFormComponent,
-    RegisterFormComponent,
-    SlidesFormComponent,
-    TestimonialFormComponent,
-    UserFormComponent,
-    UsSectionComponent,
-    SobreNosotrosComponent,
-    MostrarTitulosComponent,
-    ContactFormComponent,
-    ContactComponent,
-    ContributesInfoComponent,
-    DetailComponent,
-    OrganizationComponent,
-    ListadoNosotrosComponent,
-    InicioComponent,
-    SliderComponent,
-    DetalleNovedadComponent,
-    ProjectsComponent,
-    ProjectsComponent,
-    ListActivitiesComponent,
-    ErrorComponent,
-    ActivityContentComponent,
-    DatosContactoComponent,
-    PhonePipe,
-    ListNewsComponent,
-    FooterComponent,    
-    SearchComponent, HeaderComponent,
-
-
+  declarations: [ 
 
   ],
   exports: [
-    ActivityFormComponent,
-    LoginFormComponent,
-    RegisterFormComponent,
-    SlidesFormComponent,
-    TestimonialFormComponent,
-    UserFormComponent,
-    OrganizationComponent,
-    ProjectsComponent,
-    DetalleNovedadComponent,
     RouterModule,
-    ListNewsComponent,
-  
   ],
   imports: [
     CommonModule,
     AppRoutingModule,
     RouterModule,
-    ReactiveFormsModule,
-    CKEditorModule,
-    FormsModule,
-    MatSidenavModule,
-    MatToolbarModule,
-    MatIconModule,
-    MatButtonModule,
-    MatDialogModule,
-    SharedModule,
     StoreModule.forRoot(ROOT_REDUCERS),
     EffectsModule.forRoot([ActividadEffects]),
     StoreDevtoolsModule.instrument({ name: "TEST" }),
     BrowserAnimationsModule,
-    
   ],
 })
 export class FeaturesModule {}

--- a/src/app/features/pages/web-public-routing.module.ts
+++ b/src/app/features/pages/web-public-routing.module.ts
@@ -1,0 +1,115 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { UsSectionComponent } from './about/us-section/us-section.component';
+import { DetailComponent } from './activities/detail/detail.component';
+import { ListActivitiesComponent } from './activities/list-activities/list-activities.component';
+import { LoginFormComponent } from './auth/login-form/login-form.component';
+import { RegisterFormComponent } from './auth/register-form/register-form.component';
+import { CategoriesFormComponent } from './categories/categories-form/categories-form.component';
+import { DatosContactoComponent } from './contact/components/datos-contacto/datos-contacto.component';
+import { ContactComponent } from './contact/contact.component';
+import { InicioComponent } from './home/inicio/inicio.component';
+import { DetalleNovedadComponent } from './news/datail/detalle-novedad/detalle-novedad.component';
+import { ListNewsComponent } from './news/list-news/list-news.component';
+import { ProjectsComponent } from './projects/projects.component';
+import { TestimonialFormComponent } from './testimonials/testimonial-form/testimonial-form.component';
+import { UserFormComponent } from './users/user-form/user-form.component';
+import { WebPublicComponent } from './web-public.component';
+import { ErrorComponent } from "./error/error.component";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: WebPublicComponent,
+    children: [
+
+      {
+        path: "actividades",
+        component: ListActivitiesComponent
+      },
+
+      {
+        path: "actividades/:id",
+        component: DetailComponent
+      },
+
+      {
+        path: "testimonios",
+        component: TestimonialFormComponent
+      },
+
+      {
+        path: "categorias",
+        component: CategoriesFormComponent,
+      },
+
+      {
+        path: "proyectos",
+        component: ProjectsComponent,
+      },
+
+      {
+        path: "usuarios",
+        component: UserFormComponent,
+      },
+
+      {
+        path: "login",
+        component: LoginFormComponent
+      },
+
+      {
+        path: "register",
+        component: RegisterFormComponent,
+      },
+
+      {
+        path: "nosotros",
+        component: UsSectionComponent,
+      },
+
+      {
+        path: "contacto",
+        component: ContactComponent,
+      },
+      
+      {
+        path: "contact",
+        component: DatosContactoComponent
+      },
+
+      {
+        path: "novedades/:id",
+        component: DetalleNovedadComponent,
+      },
+
+      {
+        path: "novedades",
+        component: ListNewsComponent,
+      },
+
+      {
+        path: "home",
+        component: InicioComponent
+      },
+
+      {
+        path: "",
+        redirectTo: "home",
+        pathMatch: "full"
+      },
+
+      {
+        path: "**",
+        component: ErrorComponent
+      }
+      
+    ]
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class WebPublicRoutingModule { }

--- a/src/app/features/pages/web-public.component.html
+++ b/src/app/features/pages/web-public.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/src/app/features/pages/web-public.component.spec.ts
+++ b/src/app/features/pages/web-public.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WebPublicComponent } from './web-public.component';
+
+describe('WebPublicComponent', () => {
+  let component: WebPublicComponent;
+  let fixture: ComponentFixture<WebPublicComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ WebPublicComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WebPublicComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/pages/web-public.component.ts
+++ b/src/app/features/pages/web-public.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-web-public',
+  templateUrl: './web-public.component.html',
+  styleUrls: ['./web-public.component.scss']
+})
+export class WebPublicComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/features/pages/web-public.module.ts
+++ b/src/app/features/pages/web-public.module.ts
@@ -1,0 +1,107 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+import { WebPublicRoutingModule } from './web-public-routing.module';
+import { WebPublicComponent } from './web-public.component';
+import { PhonePipe } from 'src/app/core/pipes/phone/phone.pipe';
+import { MostrarTitulosComponent } from 'src/app/shared/components/mostrar-titulos/mostrar-titulos.component';
+import { SliderComponent as SliderPublicComponent } from "./home/slider/slider.component";
+import { ListadoNosotrosComponent } from './about/us-section/components/listado-nosotros/listado-nosotros.component';
+import { SobreNosotrosComponent } from './about/us-section/components/sobre-nosotros/sobre-nosotros.component';
+import { UsSectionComponent } from './about/us-section/us-section.component';
+import { ActivityContentComponent } from './activities/activity-content/activity-content.component';
+import { ActivityFormComponent } from './activities/activity-form/activity-form.component';
+import { DetailComponent } from './activities/detail/detail.component';
+import { ListActivitiesComponent } from './activities/list-activities/list-activities.component';
+import { SearchComponent } from './activities/search/search.component';
+import { LoginFormComponent } from './auth/login-form/login-form.component';
+import { RegisterFormComponent } from './auth/register-form/register-form.component';
+import { ContactFormComponent } from './contact/components/contact-form/contact-form.component';
+import { ContributesInfoComponent } from './contact/components/contributes-info/contributes-info.component';
+import { DatosContactoComponent } from './contact/components/datos-contacto/datos-contacto.component';
+import { ContactComponent } from './contact/contact.component';
+import { ErrorComponent } from './error/error.component';
+import { FooterComponent } from './footer/footer.component';
+import { HeaderComponent } from './header/header.component';
+import { InicioComponent } from './home/inicio/inicio.component';
+import { DetalleNovedadComponent } from './news/datail/detalle-novedad/detalle-novedad.component';
+import { ListNewsComponent } from './news/list-news/list-news.component';
+import { OrganizationComponent } from './organization/organization.component';
+import { ProjectsComponent } from './projects/projects.component';
+import { SlidesFormComponent } from './slides/slides-form/slides-form.component';
+import { TestimonialFormComponent } from './testimonials/testimonial-form/testimonial-form.component';
+import { UserFormComponent } from './users/user-form/user-form.component';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { CKEditorModule } from 'ckeditor4-angular';
+import { SharedModule } from 'src/app/shared/shared.module';
+
+
+@NgModule({
+  declarations: [
+    WebPublicComponent,
+    ActivityFormComponent,
+    LoginFormComponent,
+    RegisterFormComponent,
+    SlidesFormComponent,
+    TestimonialFormComponent,
+    UserFormComponent,
+    UsSectionComponent,
+    SobreNosotrosComponent,
+    MostrarTitulosComponent,
+    ContactFormComponent,
+    ContactComponent,
+    ContributesInfoComponent,
+    DetailComponent,
+    OrganizationComponent,
+    ListadoNosotrosComponent,
+    InicioComponent,
+    SliderPublicComponent,
+    DetalleNovedadComponent,
+    ProjectsComponent,
+    ProjectsComponent,
+    ListActivitiesComponent,
+    ErrorComponent,
+    ActivityContentComponent,
+    DatosContactoComponent,
+    PhonePipe,
+    ListNewsComponent,
+    FooterComponent,    
+    SearchComponent,
+    HeaderComponent
+  ],
+  exports: [
+    WebPublicComponent,
+    ActivityFormComponent,
+    LoginFormComponent,
+    RegisterFormComponent,
+    SlidesFormComponent,
+    TestimonialFormComponent,
+    UserFormComponent,
+    OrganizationComponent,
+    ProjectsComponent,
+    DetalleNovedadComponent,
+    RouterModule,
+    ListNewsComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterModule,
+    WebPublicRoutingModule,
+    ReactiveFormsModule,
+    CKEditorModule,
+    FormsModule,
+    MatSidenavModule,
+    MatToolbarModule,
+    MatIconModule,
+    MatButtonModule,
+    MatDialogModule,
+    SharedModule
+  ]
+})
+export class WebPublicModule { }


### PR DESCRIPTION
### DESCRIPCION

- Se creó el módulo "web-public" con su respectivo routing y se trasladaron los componentes y rutas de "features-module" y "app-routing" a ellos
- Se aplicó lazy loading para la carga del módulo creado y sus rutas
- Se agregó una redirección hacia "home" cuando la ruta inicial esté vacía, como se hacía originalmente y también se agregó una ruta de error 404 por si la ruta solicitada por el usuario no coincide con las definidas