### PR TITLE
Ft/305 149 crear documentar test registro

### DIFF
--- a/src/app/features/pages/auth/register-form/register-form.component.spec.ts
+++ b/src/app/features/pages/auth/register-form/register-form.component.spec.ts
@@ -24,9 +24,9 @@ describe('RegisterFormComponent', () => {
   };
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ RegisterFormComponent ],
-      imports: [
+    await TestBed.configureTestingModule({//proporcionamos las dependencias que usa nuestro componente en el testingModule
+      declarations: [ RegisterFormComponent ], //declaramos el componente que se usará para probar
+      imports: [ //importamos los modulos necesarios para que funcione el componente
         HttpClientModule,
         FormsModule,
         ReactiveFormsModule,
@@ -34,57 +34,59 @@ describe('RegisterFormComponent', () => {
         BrowserAnimationsModule,
         MatDialogModule
       ],
-      providers: [
+      providers: [ //proveemos el servicio que se usa en el componente y creamos un mock del store para no usar el original
         PrivateApiService,
-        provideMockStore({ initialState })
+        provideMockStore({ initialState }) //creamos un initialState falso 
       ]
     })
-    .compileComponents();
+    .compileComponents(); //y al terminar de configurar el modulo de testing se debe proceder a compilarlo
   });
 
-  beforeEach(() => {
+  beforeEach(() => { //antes de cada prueba configuraremos lo que usaremos y como lo usaremos
     fixture = TestBed.createComponent(RegisterFormComponent);
     component = fixture.componentInstance;
     service = fixture.debugElement.injector.get(PrivateApiService);
     store = TestBed.inject(MockStore);
 
-    fixture.detectChanges();
+    fixture.detectChanges(); //detectamos cambios
   });
 
-  it('should create', () => {
+  it('should create', () => { //en este test verificamos que se cree la instancia del componente correctamente
     expect(component).toBeTruthy();
   });
 
   it('debe ser invalido el formulario al no rellenarse todos los campos', () => {
-    const form = component.miFormulario;
+    const form = component.miFormulario; //accedemos al formulario y lo encerramos en una vairable para acceder de forma más facil cuando lo usemos
 
+    //procedemos a setearle valores de prueba a los campos y dejaremos uno sin llenar
     form.get("name")?.setValue("Prueba");
     form.get("email")?.setValue("pruebapararegistro@gmail.com");
     form.get("password")?.setValue("prueba123!");
     form.get("password2")?.setValue(null);
 
-    fixture.detectChanges();
+    fixture.detectChanges(); //detectamos cambios
 
-    expect(form.valid).toBeFalsy();
+    expect(form.valid).toBeFalsy(); //esperamos que el form.valid sea falso, es decir que sea invalido si no se rellenan todos los campos correctamente
   });
 
   it('debe ser valido el formulario al rellenarse todos los campos', () => {
     const form = component.miFormulario;
 
+    //hacemos el mismo procedimiento pero ahora rellenamos todos los campos correctamente
     form.get("name")?.setValue("Prueba");
     form.get("email")?.setValue("pruebapararegistro@gmail.com");
     form.get("password")?.setValue("prueba123!");
     form.get("password2")?.setValue("prueba123!");
 
-    fixture.detectChanges();
+    fixture.detectChanges(); //detectamos los cambios
 
-    expect(form.valid).toBeTruthy();
+    expect(form.valid).toBeTruthy(); //ahora esperamos que el form.valid sea true, es decir que el formulario sea valido
   });
 
   it('debe NO hacer peticiones si se hace submit y no se aceptaron los terminos y condiciones, desplegando dialog', () => {
     const form = component.miFormulario;
-    const dialogSpy = spyOn(component.dialog, 'open');
-    const requestSpy = spyOn<any>(service, 'simplePostRequest');
+    const dialogSpy = spyOn(component.dialog, 'open'); //creamos un espia que detectara cuando se llame a la funcion "open" del component.dialog
+    const requestSpy = spyOn<any>(service, 'simplePostRequest'); //creamos un espia que detectara cuando se llame a la funcion "simplePostRequest" de nuestro servicio
 
     form.get("name")?.setValue("Prueba");
     form.get("email")?.setValue("pruebapararegistro@gmail.com");
@@ -93,14 +95,16 @@ describe('RegisterFormComponent', () => {
 
     fixture.detectChanges();
 
+    //nuestro componente de registro nos pide que es necesario que se acepten los terminos y condiciones, y aqui no lo estamos aceptando
+    //ejecutaremos la funcion "registrar" de nuestro componente, que es la encargada de llamar al servicio con nuestros datos del formulario SOLO si se aceptan los terminos y condiciones
     component.registrar();
 
     fixture.detectChanges();
 
-    expect(requestSpy).not.toHaveBeenCalled();
+    expect(requestSpy).not.toHaveBeenCalled(); //esperamos que NO se llame al servicio
 
-    expect(dialogSpy).toHaveBeenCalledWith(
-      ResponseComponent, {
+    expect(dialogSpy).toHaveBeenCalledWith( //y esperamos que el dialog se abra con su respectivo componente e informando que es necesario aceptar los terminos y condiciones
+      ResponseComponent, { 
         data: {
           message: "Lea y acepte terminos y condiciones para registrarse",
           title: "DEBE ACEPTAR TERMINOS Y CONDICIONES",
@@ -113,6 +117,8 @@ describe('RegisterFormComponent', () => {
   it('debe hacer peticiones correctamente al hacer submit y aceptar terminos y condiciones, abrir dialog en caso de registro no exitoso', () => {
     const form = component.miFormulario;
     const dialogSpy = spyOn(component.dialog, 'open');
+
+    //ahora tambien crearemos un espia en el metodo del servicio, pero tambien haremos que retorne una simulacion de error para ver como reacciona nuestro componente
     const requestSpy = spyOn<any>(service, 'simplePostRequest').and.returnValue(of(
       {
         error: "Registro sin éxito"
@@ -124,7 +130,7 @@ describe('RegisterFormComponent', () => {
     form.get("password")?.setValue("prueba123!");
     form.get("password2")?.setValue("prueba123!");
 
-    component.aceptTerms = true;
+    component.aceptTerms = true; //aceptamos los terminos y condiciones para que se haga correctamente la llamada al servicio
 
     fixture.detectChanges();
 
@@ -132,9 +138,10 @@ describe('RegisterFormComponent', () => {
 
     fixture.detectChanges();
 
-    expect(requestSpy).toHaveBeenCalled();
+    expect(requestSpy).toHaveBeenCalled(); //ahora esperamos que SI se llame correctamente al metodo del servicio
 
-    expect(dialogSpy).toHaveBeenCalledWith(
+    //pero al retornar un error como respuesta, nuestro componente debe responder abriendo el dialog informando el error
+    expect(dialogSpy).toHaveBeenCalledWith( //esperamos que el dialog se abra, con su respectivo componente y la informacion debida para mostrar el error
       DialogErrorComponent, {
         width: "450px",
         height: "335px",
@@ -148,6 +155,8 @@ describe('RegisterFormComponent', () => {
   it('debe reaccionar correctamente ante la respuesta de la API de registro exitoso', () => {
     const form = component.miFormulario;
     const dialogSpy = spyOn(component.dialog, 'open');
+
+    //haremos lo mismo en este caso pero simulando una respuesta de exito por parte del servicio
     const requestSpy = spyOn<any>(service, 'simplePostRequest').and.returnValue(of(
       {
         data: [
@@ -171,9 +180,9 @@ describe('RegisterFormComponent', () => {
 
     fixture.detectChanges();
 
-    expect(requestSpy).toHaveBeenCalled();
+    expect(requestSpy).toHaveBeenCalled(); //ahora esperamos que el servicio sea llamado
 
-    expect(dialogSpy).not.toHaveBeenCalled();
+    expect(dialogSpy).not.toHaveBeenCalled(); //pero al ser un caso de exito, esperamos que NO se abra el dialog
   });
 
 });

--- a/src/app/features/pages/auth/register-form/register-form.component.spec.ts
+++ b/src/app/features/pages/auth/register-form/register-form.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
+import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { PrivateApiService } from 'src/app/core/services/privateApi/private-api.service';
@@ -49,9 +50,26 @@ describe('RegisterFormComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('', () => {
-    
+  it('debe ser invalido el formulario al no rellenarse todos los campos', () => {
+    const form = component.miFormulario;
+
+    form.get("name")?.setValue("Prueba");
+    form.get("email")?.setValue("pruebapararegistro@gmail.com");
+    form.get("password")?.setValue("prueba123!");
+    form.get("password2")?.setValue(null);
+
+    expect(form.valid).toBeFalsy();
   });
 
+  it('debe ser valido el formulario al rellenarse todos los campos', () => {
+    const form = component.miFormulario;
+
+    form.get("name")?.setValue("Prueba");
+    form.get("email")?.setValue("pruebapararegistro@gmail.com");
+    form.get("password")?.setValue("prueba123!");
+    form.get("password2")?.setValue("prueba123!");
+
+    expect(form.valid).toBeTruthy();
+  });
 
 });

--- a/src/app/features/pages/auth/register-form/register-form.component.spec.ts
+++ b/src/app/features/pages/auth/register-form/register-form.component.spec.ts
@@ -1,14 +1,37 @@
+import { HttpClientModule } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule } from '@angular/material/dialog';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { PrivateApiService } from 'src/app/core/services/privateApi/private-api.service';
 
 import { RegisterFormComponent } from './register-form.component';
 
 describe('RegisterFormComponent', () => {
   let component: RegisterFormComponent;
   let fixture: ComponentFixture<RegisterFormComponent>;
+  let service: PrivateApiService;
+  let store: MockStore;
+
+  const initialState = {
+    registerSuccess: false
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ RegisterFormComponent ]
+      declarations: [ RegisterFormComponent ],
+      imports: [
+        HttpClientModule,
+        FormsModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        MatDialogModule
+      ],
+      providers: [
+        PrivateApiService,
+        provideMockStore({ initialState })
+      ]
     })
     .compileComponents();
   });
@@ -16,10 +39,19 @@ describe('RegisterFormComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(RegisterFormComponent);
     component = fixture.componentInstance;
+    service = fixture.debugElement.injector.get(PrivateApiService);
+    store = TestBed.inject(MockStore);
+
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('', () => {
+    
+  });
+
+
 });

--- a/src/app/features/pages/auth/register-form/register-form.component.spec.ts
+++ b/src/app/features/pages/auth/register-form/register-form.component.spec.ts
@@ -3,9 +3,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { of } from 'rxjs';
 import { PrivateApiService } from 'src/app/core/services/privateApi/private-api.service';
+import { DialogErrorComponent } from 'src/app/shared/components/alertas/dialog-error/dialog-error/dialog-error.component';
+import { ResponseComponent } from 'src/app/shared/components/alertas/response.component';
 
 import { RegisterFormComponent } from './register-form.component';
 
@@ -27,6 +31,7 @@ describe('RegisterFormComponent', () => {
         FormsModule,
         ReactiveFormsModule,
         RouterTestingModule,
+        BrowserAnimationsModule,
         MatDialogModule
       ],
       providers: [
@@ -58,6 +63,8 @@ describe('RegisterFormComponent', () => {
     form.get("password")?.setValue("prueba123!");
     form.get("password2")?.setValue(null);
 
+    fixture.detectChanges();
+
     expect(form.valid).toBeFalsy();
   });
 
@@ -69,7 +76,104 @@ describe('RegisterFormComponent', () => {
     form.get("password")?.setValue("prueba123!");
     form.get("password2")?.setValue("prueba123!");
 
+    fixture.detectChanges();
+
     expect(form.valid).toBeTruthy();
+  });
+
+  it('debe NO hacer peticiones si se hace submit y no se aceptaron los terminos y condiciones, desplegando dialog', () => {
+    const form = component.miFormulario;
+    const dialogSpy = spyOn(component.dialog, 'open');
+    const requestSpy = spyOn<any>(service, 'simplePostRequest');
+
+    form.get("name")?.setValue("Prueba");
+    form.get("email")?.setValue("pruebapararegistro@gmail.com");
+    form.get("password")?.setValue("prueba123!");
+    form.get("password2")?.setValue("prueba123!");
+
+    fixture.detectChanges();
+
+    component.registrar();
+
+    fixture.detectChanges();
+
+    expect(requestSpy).not.toHaveBeenCalled();
+
+    expect(dialogSpy).toHaveBeenCalledWith(
+      ResponseComponent, {
+        data: {
+          message: "Lea y acepte terminos y condiciones para registrarse",
+          title: "DEBE ACEPTAR TERMINOS Y CONDICIONES",
+          type: "Error",
+        },
+      }
+    );
+  });
+
+  it('debe hacer peticiones correctamente al hacer submit y aceptar terminos y condiciones, abrir dialog en caso de registro no exitoso', () => {
+    const form = component.miFormulario;
+    const dialogSpy = spyOn(component.dialog, 'open');
+    const requestSpy = spyOn<any>(service, 'simplePostRequest').and.returnValue(of(
+      {
+        error: "Registro sin éxito"
+      }
+    ));
+
+    form.get("name")?.setValue("Prueba");
+    form.get("email")?.setValue("pruebapararegistro@gmail.com");
+    form.get("password")?.setValue("prueba123!");
+    form.get("password2")?.setValue("prueba123!");
+
+    component.aceptTerms = true;
+
+    fixture.detectChanges();
+
+    component.registrar();
+
+    fixture.detectChanges();
+
+    expect(requestSpy).toHaveBeenCalled();
+
+    expect(dialogSpy).toHaveBeenCalledWith(
+      DialogErrorComponent, {
+        width: "450px",
+        height: "335px",
+        data: {
+          message: "Algo salió mal, por favor revisa los datos y vuelve a intentarlo."
+        }
+      }
+    );
+  });
+
+  it('debe reaccionar correctamente ante la respuesta de la API de registro exitoso', () => {
+    const form = component.miFormulario;
+    const dialogSpy = spyOn(component.dialog, 'open');
+    const requestSpy = spyOn<any>(service, 'simplePostRequest').and.returnValue(of(
+      {
+        data: [
+          {
+            user: "Registro con éxito"
+          }
+        ]
+      }
+    ));
+
+    form.get("name")?.setValue("Prueba");
+    form.get("email")?.setValue("pruebapararegistro@gmail.com");
+    form.get("password")?.setValue("prueba123!");
+    form.get("password2")?.setValue("prueba123!");
+
+    component.aceptTerms = true;
+
+    fixture.detectChanges();
+
+    component.registrar();
+
+    fixture.detectChanges();
+
+    expect(requestSpy).toHaveBeenCalled();
+
+    expect(dialogSpy).not.toHaveBeenCalled();
   });
 
 });

--- a/src/app/features/pages/auth/register-form/register-form.component.ts
+++ b/src/app/features/pages/auth/register-form/register-form.component.ts
@@ -61,7 +61,7 @@ export class RegisterFormComponent implements OnInit {
     private fb: FormBuilder,
     private httpService: PrivateApiService,
     private store: Store,
-    private dialog: MatDialog,
+    public dialog: MatDialog,
     private router: Router
   ) {}
 


### PR DESCRIPTION
### DESCRIPCION

- Se creó el test para validar que al NO llenar todos los campos del formulario, este sea invalido
- Se creó el test para validar que al llenar todos los campos del formulario de forma correcta, este sea valido
- Se creó el test para verificar que NO se llame al servicio al hacer submit si no se aceptaron los terminos y condiciones y que a la vez se abra el dialog correspondiente
- Se creó el test para verificar que SI se llame al servicio cuando se aceptan los terminos y condiciones y ademas el componente reaccione de forma adecuada ante la respuesta de "login no exitoso" por parte de la API, abriendo el dialog de error
- Se creó el test para verificar que el componente reaccione de forma adecuada al recibir por parte de la API un registro exitoso, se espera que NO se abra el dialog